### PR TITLE
Kubernetes 1.22 support, update chart version

### DIFF
--- a/charts/eventrouter/Chart.yaml
+++ b/charts/eventrouter/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for eventrouter (https://github.com/heptiolabs/eventrouter)
 name: eventrouter
-version: 0.3.6
+version: 0.3.7
 appVersion: "0.3"
 home: https://github.com/heptiolabs/eventrouter
 sources:

--- a/charts/eventrouter/templates/clusterrole.yaml
+++ b/charts/eventrouter/templates/clusterrole.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}

--- a/charts/eventrouter/templates/clusterrolebinding.yaml
+++ b/charts/eventrouter/templates/clusterrolebinding.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.create -}}
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels: {{ include "eventrouter.labels" . | indent 4 }}


### PR DESCRIPTION
This change is needed for 1.22 (https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22),
and compatible with k8s >=1.17

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122